### PR TITLE
feat: bulle redirect mode dédié + popup configurable

### DIFF
--- a/assets/css/chatbot.css
+++ b/assets/css/chatbot.css
@@ -79,6 +79,7 @@
     --ofac-modal-height: 600px;
     --ofac-trigger-size: 60px;
     --ofac-avatar-size: 48px;
+    --ofac-trigger-offset-bottom: 8.5rem;
 }
 
 /* Dark Theme */
@@ -2672,5 +2673,139 @@
     .ofac-access-denied__card {
         padding: var(--ofac-spacing-lg) var(--ofac-spacing-md);
         margin: 0 var(--ofac-spacing-md);
+    }
+}
+
+/* ==========================================================================
+   Bubble Popup (message above the floating trigger)
+   ========================================================================== */
+
+.ofac-bubble-popup {
+    position: fixed;
+    z-index: var(--ofac-z-base);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ofac-spacing-sm);
+    max-width: 260px;
+    padding: var(--ofac-spacing-sm) var(--ofac-spacing-md);
+    padding-right: calc(var(--ofac-spacing-md) + 18px);
+    background: #ffffff;
+    color: #1e293b;
+    font-size: var(--ofac-font-size-sm);
+    font-weight: 500;
+    line-height: 1.4;
+    border-radius: var(--ofac-radius-lg);
+    box-shadow: var(--ofac-shadow-lg);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(6px);
+    transition: opacity var(--ofac-transition), transform var(--ofac-transition);
+}
+
+[data-ofac-theme="dark"] .ofac-bubble-popup {
+    background: #f8fafc;
+    color: #0f172a;
+}
+
+.ofac-bubble-popup[hidden] {
+    display: none;
+}
+
+.ofac-bubble-popup--visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+}
+
+.ofac-bubble-popup__text {
+    flex: 1 1 auto;
+}
+
+.ofac-bubble-popup__close {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    background: transparent;
+    color: inherit;
+    border: none;
+    border-radius: var(--ofac-radius-full);
+    cursor: pointer;
+    opacity: 0.55;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: opacity var(--ofac-transition), background-color var(--ofac-transition);
+}
+
+.ofac-bubble-popup__close:hover,
+.ofac-bubble-popup__close:focus-visible {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.06);
+    outline: none;
+}
+
+/* Arrow pointing to the bubble */
+.ofac-bubble-popup::after {
+    content: '';
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    background: inherit;
+    transform: rotate(45deg);
+    box-shadow: 2px 2px 4px -2px rgba(0, 0, 0, 0.1);
+}
+
+/* Position modifiers — anchored near the trigger */
+.ofac-bubble-popup--bottom-right {
+    right: var(--ofac-spacing-lg);
+    bottom: calc(var(--ofac-trigger-offset-bottom) + 14px);
+}
+.ofac-bubble-popup--bottom-right::after {
+    right: 22px;
+    bottom: -5px;
+}
+
+.ofac-bubble-popup--bottom-left {
+    left: var(--ofac-spacing-lg);
+    bottom: calc(var(--ofac-trigger-offset-bottom) + 14px);
+}
+.ofac-bubble-popup--bottom-left::after {
+    left: 22px;
+    bottom: -5px;
+}
+
+.ofac-bubble-popup--top-right {
+    right: var(--ofac-spacing-lg);
+    top: calc(var(--ofac-spacing-lg) + var(--ofac-trigger-size) + 14px);
+}
+.ofac-bubble-popup--top-right::after {
+    right: 22px;
+    top: -5px;
+    box-shadow: -2px -2px 4px -2px rgba(0, 0, 0, 0.1);
+}
+
+.ofac-bubble-popup--top-left {
+    left: var(--ofac-spacing-lg);
+    top: calc(var(--ofac-spacing-lg) + var(--ofac-trigger-size) + 14px);
+}
+.ofac-bubble-popup--top-left::after {
+    left: 22px;
+    top: -5px;
+    box-shadow: -2px -2px 4px -2px rgba(0, 0, 0, 0.1);
+}
+
+@media (max-width: 480px) {
+    .ofac-bubble-popup {
+        max-width: calc(100vw - 2 * var(--ofac-spacing-lg));
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ofac-bubble-popup {
+        transition: none;
+        transform: none;
     }
 }

--- a/assets/js/bubble-popup.js
+++ b/assets/js/bubble-popup.js
@@ -1,0 +1,66 @@
+/**
+ * OFAC Bubble Popup
+ *
+ * Shows a small message above the chatbot trigger after a configurable delay.
+ * Dismissable and persisted per-session via sessionStorage.
+ *
+ * @package Ocade_Fusion_AnythingLLM_Chatbot
+ * @since 1.2.0
+ */
+(function () {
+    'use strict';
+
+    var cfg = window.ofacBubblePopup;
+    if (!cfg || !cfg.storageKey) return;
+
+    var storageKey = cfg.storageKey;
+    var delay = Math.max(0, parseInt(cfg.delay, 10) || 0) * 1000;
+
+    function init() {
+        var popup = document.getElementById('ofac-bubble-popup');
+        if (!popup) return;
+
+        try {
+            if (sessionStorage.getItem(storageKey)) return;
+        } catch (e) {
+            // sessionStorage unavailable (private mode, etc.) — show popup anyway
+        }
+
+        var timerId = null;
+
+        var hide = function () {
+            if (timerId) { clearTimeout(timerId); timerId = null; }
+            popup.classList.remove('ofac-bubble-popup--visible');
+            popup.setAttribute('hidden', '');
+            try { sessionStorage.setItem(storageKey, '1'); } catch (e) {}
+        };
+
+        timerId = setTimeout(function () {
+            timerId = null;
+            popup.removeAttribute('hidden');
+            requestAnimationFrame(function () {
+                popup.classList.add('ofac-bubble-popup--visible');
+            });
+        }, delay);
+
+        var closeBtn = popup.querySelector('.ofac-bubble-popup__close');
+        if (closeBtn) {
+            closeBtn.addEventListener('click', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                hide();
+            }, { once: true });
+        }
+
+        var trigger = document.getElementById('ofac-trigger');
+        if (trigger) {
+            trigger.addEventListener('click', hide, { once: true });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/includes/class-ofac-chatbot.php
+++ b/includes/class-ofac-chatbot.php
@@ -144,6 +144,55 @@ class OFAC_Chatbot {
     }
 
     /**
+     * Check if the dedicated-mode redirect bubble should be displayed
+     *
+     * @return bool
+     */
+    public function should_display_redirect_bubble() {
+        if ( ! $this->is_enabled() || is_admin() ) {
+            return false;
+        }
+
+        if ( isset( $GLOBALS['pagenow'] ) && 'wp-login.php' === $GLOBALS['pagenow'] ) {
+            return false;
+        }
+
+        if ( 'dedicated' !== $this->settings->get( 'ofac_display_mode', 'floating' ) ) {
+            return false;
+        }
+
+        if ( ! $this->settings->get( 'ofac_dedicated_show_bubble', false ) ) {
+            return false;
+        }
+
+        // Never show on the dedicated page itself
+        $page_id = (int) $this->settings->get( 'ofac_dedicated_page_id', 0 );
+        if ( $page_id && is_page( $page_id ) ) {
+            return false;
+        }
+
+        /**
+         * Filter whether to display the redirect bubble
+         *
+         * @since 1.2.0
+         * @param bool $display Whether to display the redirect bubble
+         */
+        return apply_filters( 'ofac_should_display_redirect_bubble', true );
+    }
+
+    /**
+     * Get the URL of the dedicated chatbot page
+     *
+     * @return string
+     */
+    public function get_dedicated_page_url() {
+        $page_id = (int) $this->settings->get( 'ofac_dedicated_page_id', 0 );
+        $url     = $page_id ? get_permalink( $page_id ) : '';
+
+        return $url ? $url : home_url( '/' );
+    }
+
+    /**
      * Generate session ID
      *
      * @return string

--- a/includes/class-ofac-settings.php
+++ b/includes/class-ofac-settings.php
@@ -134,6 +134,32 @@ class OFAC_Settings {
                             'dedicated' => __( 'Page dédiée uniquement', 'anythingllm-chatbot' ),
                         ),
                     ),
+                    'ofac_dedicated_show_bubble' => array(
+                        'type'        => 'checkbox',
+                        'label'       => __( 'Afficher une bulle flottante (mode page dédiée)', 'anythingllm-chatbot' ),
+                        'description' => __( 'En mode « Page dédiée uniquement », affiche malgré tout une bulle flottante sur les autres pages. Au clic, l\'utilisateur est redirigé vers la page dédiée du chatbot.', 'anythingllm-chatbot' ),
+                        'default'     => false,
+                    ),
+                    'ofac_bubble_popup_enabled' => array(
+                        'type'        => 'checkbox',
+                        'label'       => __( 'Afficher un message popup au-dessus de la bulle', 'anythingllm-chatbot' ),
+                        'description' => __( 'Affiche un message d\'accroche au-dessus de la bulle flottante après un délai. Fermable par l\'utilisateur, mémorisé pour la session.', 'anythingllm-chatbot' ),
+                        'default'     => false,
+                    ),
+                    'ofac_bubble_popup_text' => array(
+                        'type'        => 'text',
+                        'label'       => __( 'Texte du popup', 'anythingllm-chatbot' ),
+                        'description' => __( 'Texte affiché dans le popup au-dessus de la bulle.', 'anythingllm-chatbot' ),
+                        'default'     => __( 'Besoin d\'aide ?', 'anythingllm-chatbot' ),
+                    ),
+                    'ofac_bubble_popup_delay' => array(
+                        'type'        => 'number',
+                        'label'       => __( 'Délai d\'apparition du popup (secondes)', 'anythingllm-chatbot' ),
+                        'description' => __( 'Délai en secondes avant l\'apparition du popup après le chargement de la page.', 'anythingllm-chatbot' ),
+                        'default'     => 5,
+                        'min'         => 0,
+                        'max'         => 120,
+                    ),
                     'ofac_position' => array(
                         'type'        => 'select',
                         'label'       => __( 'Position du bouton', 'anythingllm-chatbot' ),
@@ -537,6 +563,10 @@ class OFAC_Settings {
             'ofac_enabled'              => false,
             'ofac_display_mode'         => 'floating',
             'ofac_dedicated_page_id'    => 0,
+            'ofac_dedicated_show_bubble' => false,
+            'ofac_bubble_popup_enabled' => false,
+            'ofac_bubble_popup_text'    => 'Besoin d\'aide ?',
+            'ofac_bubble_popup_delay'   => 5,
             'ofac_position'             => 'bottom-right',
             'ofac_width_desktop'        => 400,
             'ofac_height_desktop'       => 600,
@@ -799,6 +829,9 @@ class OFAC_Settings {
             'ofac_header_avatar_size',
             'ofac_auto_open',
             'ofac_auto_open_delay',
+            'ofac_bubble_popup_enabled',
+            'ofac_bubble_popup_text',
+            'ofac_bubble_popup_delay',
         );
 
         $settings = array();

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "plugin_name": "Ocade Fusion AnythingLLM Chatbot",
   "plugin_uri": "https://ocadefusion.fr/plugins/anythingllm-chatbot",
   "description": "Intégrez un chatbot intelligent propulsé par AnythingLLM à votre site WordPress. Conforme RGAA et RGPD.",
-  "version": "1.0.26",
+  "version": "1.2.0",
   "author": "Ocade Fusion",
   "author_uri": "https://ocadefusion.fr",
   "license": "GPL v2 or later",

--- a/ocade-fusion-anythingllm-chatbot.php
+++ b/ocade-fusion-anythingllm-chatbot.php
@@ -3,7 +3,7 @@
  * Plugin Name: Ocade Fusion AnythingLLM Chatbot
  * Plugin URI: https://ocadefusion.fr/plugins/anythingllm-chatbot
  * Description: Intégrez un chatbot intelligent propulsé par AnythingLLM à votre site WordPress. Conforme RGAA et RGPD.
- * Version: 1.0.26
+ * Version: 1.2.0
  * Requires at least: 6.0
  * Requires PHP: 8.0
  * Author: Ocade Fusion
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants
-define( 'OFAC_VERSION', '1.1.0' );
+define( 'OFAC_VERSION', '1.2.0' );
 define( 'OFAC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'OFAC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'OFAC_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/public/class-ofac-public.php
+++ b/public/class-ofac-public.php
@@ -188,24 +188,46 @@ class OFAC_Public {
             true
         );
 
-        // Check if chatbot should be displayed
-        $chatbot = OFAC_Chatbot::get_instance();
-        if ( ! $chatbot->is_enabled() || ! $chatbot->should_display() ) {
+        wp_register_script(
+            'ofac-bubble-popup',
+            OFAC_PLUGIN_URL . 'assets/js/bubble-popup.js',
+            array(),
+            OFAC_VERSION,
+            true
+        );
+
+        $chatbot        = OFAC_Chatbot::get_instance();
+        $display_chat   = $chatbot->is_enabled() && $chatbot->should_display();
+        $display_bubble = $chatbot->should_display_redirect_bubble();
+
+        if ( ! $display_chat && ! $display_bubble ) {
             return;
         }
 
-        // Enqueue styles
         wp_enqueue_style( 'ofac-chatbot' );
 
-        // Enqueue main chatbot script
-        wp_enqueue_script( 'ofac-chatbot' );
+        if ( $display_chat ) {
+            wp_enqueue_script( 'ofac-chatbot' );
+            wp_localize_script(
+                'ofac-chatbot',
+                'ofacConfig',
+                $this->get_frontend_config()
+            );
+        }
 
-        // Localize settings - MUST be after enqueue
-        wp_localize_script( 
-            'ofac-chatbot',
-            'ofacConfig',
-            $this->get_frontend_config()
-        );
+        // Bubble popup: enqueue when enabled, for both floating and redirect-bubble modes
+        if ( (bool) $this->settings->get( 'ofac_bubble_popup_enabled', false )
+            && ( $display_chat || $display_bubble ) ) {
+            wp_enqueue_script( 'ofac-bubble-popup' );
+            wp_localize_script(
+                'ofac-bubble-popup',
+                'ofacBubblePopup',
+                array(
+                    'delay'      => (int) $this->settings->get( 'ofac_bubble_popup_delay', 5 ),
+                    'storageKey' => 'ofac_bubble_popup_closed',
+                )
+            );
+        }
     }
 
     /**
@@ -283,6 +305,12 @@ class OFAC_Public {
     public function render_chatbot() {
         $chatbot = OFAC_Chatbot::get_instance();
 
+        // Dedicated-mode redirect bubble (replaces full chatbot on non-dedicated pages)
+        if ( $chatbot->should_display_redirect_bubble() ) {
+            $this->render_redirect_bubble_html( $chatbot );
+            return;
+        }
+
         if ( ! $chatbot->is_enabled() || ! $chatbot->should_display() ) {
             return;
         }
@@ -293,6 +321,29 @@ class OFAC_Public {
         }
 
         $this->render_chatbot_html();
+    }
+
+    /**
+     * Render the redirect bubble HTML (dedicated mode shortcut)
+     *
+     * @param OFAC_Chatbot $chatbot Chatbot instance.
+     */
+    public function render_redirect_bubble_html( $chatbot ) {
+        $dedicated_url = $chatbot->get_dedicated_page_url();
+        $position      = $this->settings->get( 'ofac_position', 'bottom-right' );
+        $primary_color = $this->settings->get( 'ofac_primary_color', '#2563eb' );
+        $text_color    = $this->settings->get( 'ofac_text_color', '#ffffff' );
+        $popup_enabled = (bool) $this->settings->get( 'ofac_bubble_popup_enabled', false );
+        $popup_text    = $this->settings->get( 'ofac_bubble_popup_text', __( 'Besoin d\'aide ?', 'anythingllm-chatbot' ) );
+
+        $style = sprintf(
+            '--ofac-primary: %s; --ofac-primary-hover: %s; --ofac-text-inverse: %s;',
+            esc_attr( $primary_color ),
+            esc_attr( $this->adjust_brightness( $primary_color, -20 ) ),
+            esc_attr( $text_color )
+        );
+
+        include OFAC_PLUGIN_DIR . 'templates/redirect-bubble.php';
     }
 
     /**
@@ -353,6 +404,10 @@ class OFAC_Public {
         $contact_phone       = $this->settings->get( 'ofac_contact_phone', '' );
         $enable_callback_btn = (bool) $this->settings->get( 'ofac_enable_callback_btn', false );
         $callback_btn_label  = $this->settings->get( 'ofac_callback_btn_label', __( 'Être recontacté', 'anythingllm-chatbot' ) );
+
+        // Bubble popup (above floating trigger)
+        $popup_enabled = (bool) $this->settings->get( 'ofac_bubble_popup_enabled', false );
+        $popup_text    = $this->settings->get( 'ofac_bubble_popup_text', __( 'Besoin d\'aide ?', 'anythingllm-chatbot' ) );
 
         $container_class = 'ofac-chatbot';
         if ( $inline ) {

--- a/templates/chatbot.php
+++ b/templates/chatbot.php
@@ -39,7 +39,11 @@ if ( ! defined( 'ABSPATH' ) ) {
         </span>
         <span class="ofac-trigger__badge" aria-hidden="true" style="display:none;">0</span>
     </button>
-    <?php endif; ?>
+
+    <?php if ( ! empty( $popup_enabled ) ) : ?>
+        <?php include OFAC_PLUGIN_DIR . 'templates/parts/bubble-popup.php'; ?>
+    <?php endif; // popup ?>
+    <?php endif; // !inline ?>
 
     <!-- Chat Window -->
     <div id="ofac-modal" 

--- a/templates/parts/bubble-popup.php
+++ b/templates/parts/bubble-popup.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Bubble popup partial — message above the floating trigger.
+ *
+ * Included by both templates/chatbot.php (floating mode) and
+ * templates/redirect-bubble.php (dedicated-mode shortcut).
+ *
+ * Variables expected: $position, $popup_text.
+ *
+ * @package Ocade_Fusion_AnythingLLM_Chatbot
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div id="ofac-bubble-popup"
+     class="ofac-bubble-popup ofac-bubble-popup--<?php echo esc_attr( $position ); ?>"
+     role="status"
+     aria-live="polite"
+     hidden>
+    <span class="ofac-bubble-popup__text"><?php echo esc_html( $popup_text ); ?></span>
+    <button type="button"
+            class="ofac-bubble-popup__close"
+            aria-label="<?php esc_attr_e( 'Fermer le message', 'anythingllm-chatbot' ); ?>">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">
+            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+        </svg>
+    </button>
+</div>

--- a/templates/redirect-bubble.php
+++ b/templates/redirect-bubble.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Redirect bubble template (dedicated mode shortcut).
+ *
+ * Renders a floating bubble that redirects to the dedicated chatbot page
+ * when `ofac_display_mode=dedicated` and `ofac_dedicated_show_bubble=true`.
+ *
+ * Variables: $dedicated_url, $position, $style, $popup_enabled, $popup_text.
+ *
+ * @package Ocade_Fusion_AnythingLLM_Chatbot
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div id="ofac-redirect-bubble"
+     class="ofac-chatbot ofac-chatbot--redirect ofac-position-<?php echo esc_attr( $position ); ?>"
+     style="<?php echo esc_attr( $style ); ?>">
+
+    <?php if ( $popup_enabled ) : ?>
+        <?php include OFAC_PLUGIN_DIR . 'templates/parts/bubble-popup.php'; ?>
+    <?php endif; ?>
+
+    <a id="ofac-trigger"
+       href="<?php echo esc_url( $dedicated_url ); ?>"
+       class="ofac-trigger ofac-trigger--<?php echo esc_attr( $position ); ?>"
+       aria-label="<?php esc_attr_e( 'Ouvrir le chatbot', 'anythingllm-chatbot' ); ?>">
+        <span class="ofac-trigger__icon ofac-trigger__icon--chat" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="28" height="28" fill="currentColor">
+                <path d="M12 3c5.5 0 10 3.58 10 8s-4.5 8-10 8c-1.24 0-2.43-.18-3.53-.5C5.55 21 2 21 2 21c2.33-2.33 2.7-3.9 2.75-4.5C3.05 15.07 2 13.13 2 11c0-4.42 4.5-8 10-8z"/>
+            </svg>
+        </span>
+    </a>
+</div>


### PR DESCRIPTION
## Résumé
Résout [#14](https://github.com/ocade-graciet-system/ocade-chatbot-anything-llm-n8n/issues/14) : ajoute deux options indépendantes au plugin WordPress pour améliorer la découvrabilité du chatbot en mode **page dédiée**.

### Nouveautés fonctionnelles

1. **Bulle flottante de redirection** (mode dédié uniquement)
   - Option `ofac_dedicated_show_bubble` — affiche une bulle flottante sur toutes les pages **sauf** la page dédiée elle-même.
   - Au clic : redirection vers l'URL de la page dédiée (`get_permalink( ofac_dedicated_page_id )`, ex : `/chatbot/`).

2. **Popup "Besoin d'aide ?"** au-dessus de la bulle
   - Fonctionne en mode `floating` **et** avec la nouvelle bulle redirect.
   - Options : `ofac_bubble_popup_enabled` (on/off), `ofac_bubble_popup_text` (libre, défaut `Besoin d'aide ?`), `ofac_bubble_popup_delay` (secondes, défaut 5, max 120).
   - Fermable par l'utilisateur (croix), mémorisé pour la session via `sessionStorage`.

### Non-régression
Le cas `mode dédié + bulle redirect désactivée` reste strictement identique à la v1.1.0 : aucune bulle sur les autres pages.

## Fichiers touchés
| Type | Fichier |
|---|---|
| Modifié | `includes/class-ofac-settings.php` (4 nouvelles options) |
| Modifié | `includes/class-ofac-chatbot.php` (`should_display_redirect_bubble`, `get_dedicated_page_url`) |
| Modifié | `public/class-ofac-public.php` (enqueue + render dual-mode) |
| Modifié | `templates/chatbot.php` (inclusion partial popup) |
| Modifié | `assets/css/chatbot.css` (+135 lignes `.ofac-bubble-popup`) |
| Modifié | `ocade-fusion-anythingllm-chatbot.php`, `metadata.json` (version → 1.2.0) |
| Créé | `templates/redirect-bubble.php` |
| Créé | `templates/parts/bubble-popup.php` (partial factorisé) |
| Créé | `assets/js/bubble-popup.js` |

## Test plan
- [ ] Admin : les 4 nouveaux champs apparaissent dans **Paramètres généraux** et se sauvegardent.
- [ ] Mode `floating` + popup off : bulle classique, pas de popup (non-régression).
- [ ] Mode `floating` + popup on (delay 3s) : popup glisse au-dessus de la bulle après 3s, fermable, refresh ne le ré-affiche pas (sessionStorage).
- [ ] Mode `dedicated` + `show_bubble` off : aucune bulle sur les pages classiques (non-régression stricte v1.1.0).
- [ ] Mode `dedicated` + `show_bubble` on : bulle flottante sur toutes les pages **sauf** `/chatbot/` ; clic → redirection `/chatbot/` ; popup (si activé) apparaît après délai.
- [ ] Onglet privé : popup ré-apparaît normalement (sessionStorage vide).
- [ ] Console browser : aucune erreur JS dans les 5 scénarios.
- [ ] Accessibilité : bulle redirect = `<a>` avec `aria-label`, focusable clavier ; popup = `role="status"` + `aria-live="polite"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)